### PR TITLE
feat: make homepage hero, about preview, and about hero image CMS-editable

### DIFF
--- a/docs/cms-guide.md
+++ b/docs/cms-guide.md
@@ -41,8 +41,10 @@ The trainer profile appears on the **homepage** (about section) and the **About 
 
 **What you can change:**
 - **Name**
+- **Short bio** — one-liner shown on the homepage about section
 - **Bio** — rich text shown on the About page
-- **Photo** — shown on the About page
+- **Photo** — circular portrait shown on the About page
+- **Hero image** — banner image shown at the top of the About page
 - **Qualifications** — list of year + description, shown on the About page
 
 ### Community Events
@@ -62,11 +64,12 @@ Events are shown in date order (earliest first). Past events remain visible unti
 Global settings for the website.
 
 **What you can change:**
+- **Hero tagline** — the text shown below the Moontide logo on the homepage (the pronunciation and definition). Use line breaks to separate lines: first line appears in italics, second line in small text, remaining lines as normal text.
 - **Contact email**
 - **Instagram URL**
 - **Footer links**
 
-> **Note:** Site Settings are not currently wired into the website — changes here won't appear yet. This will be connected in a future update.
+> **Note:** Contact email, Instagram URL, and footer links are not currently wired into the website — changes to these fields won't appear yet. The hero tagline is live.
 
 ---
 
@@ -75,7 +78,7 @@ Global settings for the website.
 These parts of the website are built into the code and need a developer to change:
 
 - Navigation menu links and structure
-- Page layouts, section order, and design
+- Page layouts and section order
 - The booking page (driven by the database, not Sanity)
 - Contact form
 - Terms and conditions page

--- a/docs/superpowers/plans/2026-04-14-cms-editability.md
+++ b/docs/superpowers/plans/2026-04-14-cms-editability.md
@@ -1,0 +1,509 @@
+# CMS Editability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the homepage hero tagline, homepage about preview, and About page hero image editable via Sanity CMS.
+
+**Architecture:** Add fields to existing Sanity schemas (siteSettings, trainer), update GROQ query projections and TypeScript types, then wire the data through to the React components. All changes follow the existing pattern of Sanity fetch → fallback if null.
+
+**Tech Stack:** Sanity CMS, Next.js 16, React 19, TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-04-14-cms-editability-design.md`
+
+---
+
+### Task 1: Add heroTagline to siteSettings schema, query, and types
+
+**Files:**
+- Modify: `src/sanity/schema/site-settings.ts`
+- Modify: `src/lib/sanity/queries.ts`
+- Modify: `src/lib/sanity/types.ts`
+
+- [ ] **Step 1: Add heroTagline field to siteSettings schema**
+
+In `src/sanity/schema/site-settings.ts`, add a new field after `contactEmail`:
+
+```typescript
+defineField({
+  name: "heroTagline",
+  title: "Hero Tagline",
+  type: "text",
+  rows: 4,
+  description: "Text shown below the logo on the homepage. Use line breaks to separate lines (e.g. pronunciation on one line, definition on the next).",
+}),
+```
+
+- [ ] **Step 2: Add heroTagline to siteSettingsQuery projection**
+
+In `src/lib/sanity/queries.ts`, change the `siteSettingsQuery` from:
+
+```
+export const siteSettingsQuery = `*[_type == "siteSettings"][0]{
+  title,
+  contactEmail,
+  instagramUrl,
+  footerLinks
+}`;
+```
+
+to:
+
+```
+export const siteSettingsQuery = `*[_type == "siteSettings"][0]{
+  title,
+  heroTagline,
+  contactEmail,
+  instagramUrl,
+  footerLinks
+}`;
+```
+
+- [ ] **Step 3: Add heroTagline to SiteSettings interface**
+
+In `src/lib/sanity/types.ts`, add to the `SiteSettings` interface:
+
+```typescript
+export interface SiteSettings {
+  title: string;
+  heroTagline?: string;
+  contactEmail: string;
+  instagramUrl?: string;
+  footerLinks?: { label: string; href: string }[];
+}
+```
+
+- [ ] **Step 4: Verify typecheck passes**
+
+Run: `just typecheck`
+
+Expected: Clean exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sanity/schema/site-settings.ts src/lib/sanity/queries.ts src/lib/sanity/types.ts
+git commit -m "feat: add heroTagline field to siteSettings schema"
+```
+
+---
+
+### Task 2: Add shortBio and heroImage to trainer schema, query, and types
+
+**Files:**
+- Modify: `src/sanity/schema/trainer.ts`
+- Modify: `src/lib/sanity/queries.ts`
+- Modify: `src/lib/sanity/types.ts`
+
+- [ ] **Step 1: Add shortBio and heroImage fields to trainer schema**
+
+In `src/sanity/schema/trainer.ts`, add two new fields after `name`:
+
+```typescript
+defineField({
+  name: "shortBio",
+  title: "Short Bio",
+  type: "string",
+  description: "One-liner shown on the homepage about section (e.g. 'Yoga teacher and transformational coach...')",
+}),
+defineField({
+  name: "heroImage",
+  title: "Hero Image",
+  type: "image",
+  options: { hotspot: true },
+  description: "Banner image shown at the top of the About page",
+}),
+```
+
+- [ ] **Step 2: Add shortBio and heroImage to trainerQuery projection**
+
+In `src/lib/sanity/queries.ts`, change the `trainerQuery` from:
+
+```
+export const trainerQuery = `*[_type == "trainer"][0]{
+  _id,
+  name,
+  bio,
+  photo,
+  qualifications
+}`;
+```
+
+to:
+
+```
+export const trainerQuery = `*[_type == "trainer"][0]{
+  _id,
+  name,
+  shortBio,
+  bio,
+  photo,
+  heroImage,
+  qualifications
+}`;
+```
+
+- [ ] **Step 3: Add shortBio and heroImage to Trainer interface**
+
+In `src/lib/sanity/types.ts`, update the `Trainer` interface:
+
+```typescript
+export interface Trainer {
+  _id: string;
+  name: string;
+  shortBio?: string;
+  bio?: PortableTextBlock[];
+  photo?: Image;
+  heroImage?: Image;
+  qualifications?: { year: string; description: string }[];
+}
+```
+
+- [ ] **Step 4: Verify typecheck passes**
+
+Run: `just typecheck`
+
+Expected: Clean exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sanity/schema/trainer.ts src/lib/sanity/queries.ts src/lib/sanity/types.ts
+git commit -m "feat: add shortBio and heroImage fields to trainer schema"
+```
+
+---
+
+### Task 3: Wire homepage hero to CMS
+
+**Files:**
+- Modify: `src/components/hero.tsx`
+- Modify: `src/app/page.tsx`
+
+- [ ] **Step 1: Update Hero component to accept and render tagline prop**
+
+Replace the entire contents of `src/components/hero.tsx` with:
+
+```typescript
+import Image from "next/image";
+import Link from "next/link";
+
+const fallbackTagline = `moontide
+/ˈmuːn.taɪd/ · noun
+The pull of the moon on the tides — a reminder that change is natural, cyclical, and part of who we are.`;
+
+interface HeroProps {
+  imageUrl?: string;
+  tagline?: string;
+}
+
+export function Hero({ imageUrl, tagline }: HeroProps) {
+  const lines = (tagline || fallbackTagline).split("\n").filter(Boolean);
+
+  return (
+    <section className="relative min-h-[70vh] flex items-center justify-center">
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt="Moon over water"
+          fill
+          className="object-cover"
+          priority
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-b from-ocean-light-blue via-soft-moonstone/50 to-dawn-light" />
+      )}
+      <div className="relative z-10 text-center px-6 py-16">
+        <Image
+          src="/images/moontide-icon.png"
+          alt=""
+          width={351}
+          height={234}
+          className="h-24 md:h-32 w-auto mx-auto mb-4"
+          priority
+        />
+        <h1 className="text-4xl md:text-5xl font-light tracking-[0.12em] text-deep-tide-blue mb-4">
+          Moontide
+        </h1>
+        <div className="max-w-md mx-auto mb-8 space-y-1">
+          {lines.map((line, i) => (
+            <p
+              key={i}
+              className={
+                i === 0
+                  ? "text-deep-ocean italic"
+                  : i === 1
+                    ? "text-sm text-deep-ocean"
+                    : "text-deep-ocean leading-relaxed"
+              }
+            >
+              {line}
+            </p>
+          ))}
+        </div>
+        <div className="flex gap-3 justify-center flex-wrap">
+          <Link
+            href="/book"
+            className="bg-bright-orange text-dawn-light px-6 py-3 rounded-md font-semibold text-sm hover:bg-bright-orange/90 transition-colors"
+          >
+            Book a Class
+          </Link>
+          <Link
+            href="/about"
+            className="border border-deep-tide-blue text-deep-tide-blue px-6 py-3 rounded-md text-sm hover:bg-deep-tide-blue hover:text-dawn-light transition-colors"
+          >
+            Learn More
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+The styling logic: first line is italic (the word "moontide"), second line is small (pronunciation), remaining lines are normal body text (the definition). This matches the current hardcoded layout.
+
+- [ ] **Step 2: Update homepage to fetch siteSettings and pass tagline**
+
+In `src/app/page.tsx`, replace the entire file with:
+
+```typescript
+import { AboutPreview } from "@/components/about-preview";
+import { BookingOptions } from "@/components/booking-options";
+import { ContactForm } from "@/components/contact-form";
+import { Hero } from "@/components/hero";
+import { ServicesSection } from "@/components/services-section";
+import { sanityClient, urlFor } from "@/lib/sanity/client";
+import {
+  servicesQuery,
+  siteSettingsQuery,
+  trainerQuery,
+} from "@/lib/sanity/queries";
+import type { Service, SiteSettings, Trainer } from "@/lib/sanity/types";
+
+export const revalidate = 3600;
+
+export default async function HomePage() {
+  const [services, trainer, siteSettings] = await Promise.all([
+    sanityClient.fetch<Service[]>(servicesQuery),
+    sanityClient.fetch<Trainer | null>(trainerQuery),
+    sanityClient.fetch<SiteSettings | null>(siteSettingsQuery),
+  ]);
+
+  const photoUrl = trainer?.photo
+    ? urlFor(trainer.photo).width(160).height(160).url()
+    : undefined;
+
+  return (
+    <>
+      <Hero tagline={siteSettings?.heroTagline ?? undefined} />
+      <BookingOptions />
+      <ServicesSection services={services} />
+      {trainer && (
+        <AboutPreview
+          name={trainer.name}
+          shortBio={
+            trainer.shortBio ??
+            "Yoga teacher and transformational coach supporting women through every phase of life."
+          }
+          photoUrl={photoUrl}
+        />
+      )}
+      <section className="py-16 px-6 bg-dawn-light">
+        <div className="max-w-lg mx-auto">
+          <h2 className="text-xl font-semibold text-deep-tide-blue text-center mb-1">
+            Leave a message
+          </h2>
+          <div className="w-8 h-0.5 bg-bright-orange mx-auto mb-8" />
+          <ContactForm />
+        </div>
+      </section>
+    </>
+  );
+}
+```
+
+Changes from current:
+- Imports `siteSettingsQuery`, `SiteSettings`, `urlFor`
+- Fetches `siteSettings` in the Promise.all
+- Passes `siteSettings.heroTagline` to Hero
+- Builds `photoUrl` from `trainer.photo` and passes to AboutPreview
+- Uses `trainer.shortBio` with fallback instead of hardcoded string
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `just typecheck`
+
+Expected: Clean exit.
+
+- [ ] **Step 4: Verify tests pass**
+
+Run: `just test`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/hero.tsx src/app/page.tsx
+git commit -m "feat: wire homepage hero tagline and about preview to CMS"
+```
+
+---
+
+### Task 4: Add hero image to About page
+
+**Files:**
+- Modify: `src/app/about/page.tsx`
+
+- [ ] **Step 1: Add hero image section to About page**
+
+In `src/app/about/page.tsx`, add the hero image section. The file currently starts rendering with `{/* Hero */}` which is just a text heading. Add an image hero before it.
+
+Find:
+
+```typescript
+  const photoUrl = trainer?.photo
+    ? urlFor(trainer.photo).width(320).height(320).url()
+    : null;
+
+  return (
+    <>
+      {/* Hero */}
+      <section className="py-16 px-6 bg-dawn-light">
+```
+
+Replace with:
+
+```typescript
+  const photoUrl = trainer?.photo
+    ? urlFor(trainer.photo).width(320).height(320).url()
+    : null;
+
+  const heroImageUrl = trainer?.heroImage
+    ? urlFor(trainer.heroImage).width(1200).height(500).url()
+    : null;
+
+  return (
+    <>
+      {/* Hero image */}
+      <div className="relative h-64 md:h-96 bg-ocean-light-blue/30">
+        {heroImageUrl ? (
+          <Image
+            src={heroImageUrl}
+            alt="About Moontide"
+            fill
+            className="object-cover"
+            priority
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-deep-ocean/40">
+            [ Photography — about ]
+          </div>
+        )}
+      </div>
+
+      {/* Hero */}
+      <section className="py-16 px-6 bg-dawn-light">
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `just typecheck`
+
+Expected: Clean exit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/about/page.tsx
+git commit -m "feat: add CMS-editable hero image to About page"
+```
+
+---
+
+### Task 5: Update CMS guide
+
+**Files:**
+- Modify: `docs/cms-guide.md`
+
+- [ ] **Step 1: Update Site Settings section**
+
+In `docs/cms-guide.md`, find the Site Settings section:
+
+```markdown
+### Site Settings
+
+Global settings for the website.
+
+**What you can change:**
+- **Contact email**
+- **Instagram URL**
+- **Footer links**
+
+> **Note:** Site Settings are not currently wired into the website — changes here won't appear yet. This will be connected in a future update.
+```
+
+Replace with:
+
+```markdown
+### Site Settings
+
+Global settings for the website.
+
+**What you can change:**
+- **Hero tagline** — the text shown below the Moontide logo on the homepage (the pronunciation and definition). Use line breaks to separate lines: first line appears in italics, second line in small text, remaining lines as normal text.
+- **Contact email**
+- **Instagram URL**
+- **Footer links**
+
+> **Note:** Contact email, Instagram URL, and footer links are not currently wired into the website — changes to these fields won't appear yet. The hero tagline is live.
+```
+
+- [ ] **Step 2: Update Trainers section**
+
+Find the Trainers section:
+
+```markdown
+**What you can change:**
+- **Name**
+- **Bio** — rich text shown on the About page
+- **Photo** — shown on the About page
+- **Qualifications** — list of year + description, shown on the About page
+```
+
+Replace with:
+
+```markdown
+**What you can change:**
+- **Name**
+- **Short bio** — one-liner shown on the homepage about section
+- **Bio** — rich text shown on the About page
+- **Photo** — circular portrait shown on the About page
+- **Hero image** — banner image shown at the top of the About page
+- **Qualifications** — list of year + description, shown on the About page
+```
+
+- [ ] **Step 3: Update "What you cannot edit" section**
+
+In the list of things that cannot be edited, remove "Page layouts, section order, and design" since some layout content is now editable. The line should stay but be reworded. Find:
+
+```markdown
+- Navigation menu links and structure
+- Page layouts, section order, and design
+- The booking page (driven by the database, not Sanity)
+```
+
+Replace with:
+
+```markdown
+- Navigation menu links and structure
+- Page layouts and section order
+- The booking page (driven by the database, not Sanity)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/cms-guide.md
+git commit -m "docs: update CMS guide with new editable fields"
+```

--- a/docs/superpowers/specs/2026-04-14-cms-editability-design.md
+++ b/docs/superpowers/specs/2026-04-14-cms-editability-design.md
@@ -1,0 +1,128 @@
+# CMS Editability: Homepage Hero, About Preview, About Page Hero
+
+**Date:** 2026-04-14
+**Status:** Approved
+**Scope:** Make three currently-hardcoded sections editable via Sanity CMS, and add a hero image to the About page.
+
+---
+
+## Problem
+
+Several prominent sections of the site have content hardcoded in React components that should be editable by Gabrielle in Sanity:
+
+1. The homepage hero tagline (definition, pronunciation, italic text)
+2. The homepage "about me" preview (short bio text and photo)
+3. The About page has no hero image, unlike every other content page
+
+---
+
+## 1. Site Settings — Hero Tagline
+
+### Schema change (`siteSettings`)
+
+Add a `heroTagline` field (plain text, multiline) for the homepage hero text block. This replaces the hardcoded pronunciation/definition text.
+
+```
+heroTagline: text (multiline, optional)
+```
+
+Default/fallback: the current hardcoded text ("moontide\n/ˈmuːn.taɪd/ · noun\nThe pull of the moon on the tides — a reminder that change is natural, cyclical, and part of who we are.")
+
+### Query change
+
+The existing `siteSettingsQuery` already fetches from `siteSettings`. Add `heroTagline` to the projection.
+
+### Rendering change (`Hero` component)
+
+The Hero component currently hardcodes three `<p>` tags for the tagline. Instead, accept a `tagline` prop (string) and render it by splitting on newlines into paragraphs. If null/empty, use the current hardcoded text as fallback.
+
+### Homepage data flow
+
+The homepage (`src/app/page.tsx`) already fetches services and trainer. Add a `siteSettings` fetch (using the existing query) and pass `siteSettings.heroTagline` to the Hero component.
+
+---
+
+## 2. Trainer — Short Bio and Homepage About Preview
+
+### Schema change (`trainer`)
+
+Add a `shortBio` field (plain string, not rich text) for the one-liner used on the homepage about preview.
+
+```
+shortBio: string (optional)
+```
+
+Default/fallback: "Yoga teacher and transformational coach supporting women through every phase of life."
+
+### Schema change (`trainer`) — Hero Image
+
+Add a `heroImage` field (image with hotspot) for the About page hero banner.
+
+```
+heroImage: image (optional, hotspot: true)
+```
+
+### Query change
+
+The existing `trainerQuery` needs `shortBio` and `heroImage` added to the projection.
+
+### Type change
+
+Add `shortBio?: string` and `heroImage?: Image` to the `Trainer` interface.
+
+### Homepage about preview
+
+The homepage currently passes a hardcoded `shortBio` string to `AboutPreview`. Change to:
+- Pass `trainer.shortBio` (with hardcoded fallback if null)
+- Pass `trainer.photo` as `photoUrl` (currently not passed at all — the photo exists in Sanity but the homepage doesn't use it)
+
+---
+
+## 3. About Page — Hero Image
+
+### Rendering change
+
+Add a hero image section at the top of the About page, matching the pattern used on class detail, coaching, community, and private pages:
+
+```tsx
+<div className="relative h-64 md:h-96 bg-ocean-light-blue/30">
+  {imageUrl ? <Image ... /> : <placeholder />}
+</div>
+```
+
+Use `trainer.heroImage` (not `trainer.photo` — that's the circular portrait). If `heroImage` is null, show the gradient placeholder.
+
+---
+
+## 4. CMS Guide Update
+
+Update `docs/cms-guide.md`:
+- Add `heroTagline` to the Site Settings section (and remove the "not currently wired" note — Site Settings is now partially wired)
+- Add `shortBio` and `heroImage` to the Trainers section
+- Update the "What you cannot edit" section to remove items that are now editable
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/sanity/schema/site-settings.ts` | Add `heroTagline` field |
+| `src/sanity/schema/trainer.ts` | Add `shortBio` and `heroImage` fields |
+| `src/lib/sanity/queries.ts` | Add fields to `siteSettingsQuery` and `trainerQuery` projections |
+| `src/lib/sanity/types.ts` | Add fields to `SiteSettings` and `Trainer` interfaces |
+| `src/components/hero.tsx` | Accept `tagline` prop, render with newline splitting, fallback |
+| `src/components/about-preview.tsx` | No change needed (already accepts `photoUrl` and `shortBio` props) |
+| `src/app/page.tsx` | Fetch siteSettings, pass tagline to Hero, pass photo + shortBio to AboutPreview |
+| `src/app/about/page.tsx` | Add hero image section using `trainer.heroImage` |
+| `docs/cms-guide.md` | Document new editable fields |
+| `AGENTS.md` | No change needed (revalidation already covers siteSettings and trainer) |
+
+## Revalidation
+
+Already handled — the webhook maps `siteSettings` → `/` and `trainer` → `/`, `/about`. No changes needed.
+
+## Out of Scope
+
+- Wiring footer/nav to siteSettings (separate task)
+- Making button text or navigation CMS-editable

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -49,8 +49,29 @@ export default async function AboutPage() {
     ? urlFor(trainer.photo).width(320).height(320).url()
     : null;
 
+  const heroImageUrl = trainer?.heroImage
+    ? urlFor(trainer.heroImage).width(1200).height(500).url()
+    : null;
+
   return (
     <>
+      {/* Hero image */}
+      <div className="relative h-64 md:h-96 bg-ocean-light-blue/30">
+        {heroImageUrl ? (
+          <Image
+            src={heroImageUrl}
+            alt="About Moontide"
+            fill
+            className="object-cover"
+            priority
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-deep-ocean/40">
+            [ Photography — about ]
+          </div>
+        )}
+      </div>
+
       {/* Hero */}
       <section className="py-16 px-6 bg-dawn-light">
         <div className="max-w-2xl mx-auto text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,27 +3,40 @@ import { BookingOptions } from "@/components/booking-options";
 import { ContactForm } from "@/components/contact-form";
 import { Hero } from "@/components/hero";
 import { ServicesSection } from "@/components/services-section";
-import { sanityClient } from "@/lib/sanity/client";
-import { servicesQuery, trainerQuery } from "@/lib/sanity/queries";
-import type { Service, Trainer } from "@/lib/sanity/types";
+import { sanityClient, urlFor } from "@/lib/sanity/client";
+import {
+  servicesQuery,
+  siteSettingsQuery,
+  trainerQuery,
+} from "@/lib/sanity/queries";
+import type { Service, SiteSettings, Trainer } from "@/lib/sanity/types";
 
 export const revalidate = 3600;
 
 export default async function HomePage() {
-  const [services, trainer] = await Promise.all([
+  const [services, trainer, siteSettings] = await Promise.all([
     sanityClient.fetch<Service[]>(servicesQuery),
     sanityClient.fetch<Trainer | null>(trainerQuery),
+    sanityClient.fetch<SiteSettings | null>(siteSettingsQuery),
   ]);
+
+  const photoUrl = trainer?.photo
+    ? urlFor(trainer.photo).width(160).height(160).url()
+    : undefined;
 
   return (
     <>
-      <Hero />
+      <Hero tagline={siteSettings?.heroTagline ?? undefined} />
       <BookingOptions />
       <ServicesSection services={services} />
       {trainer && (
         <AboutPreview
           name={trainer.name}
-          shortBio="Yoga teacher and transformational coach supporting women through every phase of life."
+          shortBio={
+            trainer.shortBio ??
+            "Yoga teacher and transformational coach supporting women through every phase of life."
+          }
+          photoUrl={photoUrl}
         />
       )}
       <section className="py-16 px-6 bg-dawn-light">

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,11 +1,18 @@
 import Image from "next/image";
 import Link from "next/link";
 
+const fallbackTagline = `moontide
+/ˈmuːn.taɪd/ · noun
+The pull of the moon on the tides — a reminder that change is natural, cyclical, and part of who we are.`;
+
 interface HeroProps {
   imageUrl?: string;
+  tagline?: string;
 }
 
-export function Hero({ imageUrl }: HeroProps) {
+export function Hero({ imageUrl, tagline }: HeroProps) {
+  const lines = (tagline || fallbackTagline).split("\n").filter(Boolean);
+
   return (
     <section className="relative min-h-[70vh] flex items-center justify-center">
       {imageUrl ? (
@@ -31,12 +38,22 @@ export function Hero({ imageUrl }: HeroProps) {
         <h1 className="text-4xl md:text-5xl font-light tracking-[0.12em] text-deep-tide-blue mb-4">
           Moontide
         </h1>
-        <p className="text-deep-ocean max-w-md mx-auto mb-2 italic">moontide</p>
-        <p className="text-sm text-deep-ocean mb-1">/ˈmuːn.taɪd/ · noun</p>
-        <p className="text-deep-ocean max-w-sm mx-auto mb-8 leading-relaxed">
-          The pull of the moon on the tides — a reminder that change is natural,
-          cyclical, and part of who we are.
-        </p>
+        <div className="max-w-md mx-auto mb-8 space-y-1">
+          {lines.map((line, i) => (
+            <p
+              key={i}
+              className={
+                i === 0
+                  ? "text-deep-ocean italic"
+                  : i === 1
+                    ? "text-sm text-deep-ocean"
+                    : "text-deep-ocean leading-relaxed"
+              }
+            >
+              {line}
+            </p>
+          ))}
+        </div>
         <div className="flex gap-3 justify-center flex-wrap">
           <Link
             href="/book"

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -39,7 +39,9 @@ export const communityEventsQuery = `*[_type == "communityEvent"] | order(date a
 export const trainerQuery = `*[_type == "trainer"][0]{
   _id,
   name,
+  shortBio,
   bio,
   photo,
+  heroImage,
   qualifications
 }`;

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -1,5 +1,6 @@
 export const siteSettingsQuery = `*[_type == "siteSettings"][0]{
   title,
+  heroTagline,
   contactEmail,
   instagramUrl,
   footerLinks

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -2,6 +2,7 @@ import type { Image, PortableTextBlock } from "sanity";
 
 export interface SiteSettings {
   title: string;
+  heroTagline?: string;
   contactEmail: string;
   instagramUrl?: string;
   footerLinks?: { label: string; href: string }[];

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -31,7 +31,9 @@ export interface CommunityEvent {
 export interface Trainer {
   _id: string;
   name: string;
+  shortBio?: string;
   bio?: PortableTextBlock[];
   photo?: Image;
+  heroImage?: Image;
   qualifications?: { year: string; description: string }[];
 }

--- a/src/sanity/schema/site-settings.ts
+++ b/src/sanity/schema/site-settings.ts
@@ -18,6 +18,14 @@ export const siteSettings = defineType({
       initialValue: "gwaring5@googlemail.com",
     }),
     defineField({
+      name: "heroTagline",
+      title: "Hero Tagline",
+      type: "text",
+      rows: 4,
+      description:
+        "Text shown below the logo on the homepage. Use line breaks to separate lines (e.g. pronunciation on one line, definition on the next).",
+    }),
+    defineField({
       name: "instagramUrl",
       title: "Instagram URL",
       type: "url",

--- a/src/sanity/schema/trainer.ts
+++ b/src/sanity/schema/trainer.ts
@@ -12,6 +12,20 @@ export const trainer = defineType({
       validation: (rule) => rule.required(),
     }),
     defineField({
+      name: "shortBio",
+      title: "Short Bio",
+      type: "string",
+      description:
+        "One-liner shown on the homepage about section (e.g. 'Yoga teacher and transformational coach...')",
+    }),
+    defineField({
+      name: "heroImage",
+      title: "Hero Image",
+      type: "image",
+      options: { hotspot: true },
+      description: "Banner image shown at the top of the About page",
+    }),
+    defineField({
       name: "bio",
       title: "Bio",
       type: "array",


### PR DESCRIPTION
## Summary

- Add `heroTagline` field to Site Settings — edits the homepage hero text below the logo
- Add `shortBio` field to Trainer — one-liner for the homepage about section (was hardcoded)
- Add `heroImage` field to Trainer — banner image for the About page hero (was missing)
- Wire homepage to fetch siteSettings and pass tagline to Hero component
- Pass trainer photo and shortBio to AboutPreview (photo wasn't being passed before)
- Add hero image section to About page matching other content pages
- Update CMS guide with new editable fields

## Test plan

- [ ] CI passes
- [ ] Homepage hero shows fallback tagline (no CMS value set yet)
- [ ] Homepage about section shows trainer photo from CMS
- [ ] About page shows hero image placeholder (until Gabrielle uploads one)
- [ ] After merge: Gabrielle can edit hero tagline in Site Settings and see it update

🤖 Generated with [Claude Code](https://claude.com/claude-code)