### PR TITLE
feat: Stripe setup and confirmed pricing

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,4 @@
 node = "22"
 pnpm = "9"
 just = "latest"
+stripe = "latest"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ drizzle/
 - **Admin APIs:** Routes at `/api/admin/*` — not separately auth-protected (rely on proxy for page access).
 - **Stripe webhook:** At `/api/stripe/webhook` — reads raw body for signature verification, never parse JSON before verifying.
 - **Booking flow:** `/api/book/checkout` (Stripe Checkout) and `/api/book/redeem` (bundle credit). Checkout handles both individual and bundle purchases via `type` field.
-- **Prices in pence:** Class prices stored in `classes.priceInPence`. Bundle price is a constant in the checkout route (£75 / 7500 pence for 6 classes).
+- **Prices in pence:** Class prices stored in `classes.priceInPence` (£12.50 / 1250 pence). Bundle price is a constant in the checkout route (£66 / 6600 pence for 6 classes).
 - **Bundle redemption:** Email-based lookup, no customer auth required. 90-day expiry from purchase.
 - **DB transactions:** Multi-step mutations (e.g., booking insert + count increment) wrapped in `db.transaction()` for atomicity.
 - **CI/CD:** GitHub Actions runs lint, typecheck, and test on PRs and pushes to master. No secrets needed in CI — all tests use mocks.

--- a/justfile
+++ b/justfile
@@ -50,3 +50,7 @@ db-seed-cms:
 # Open Drizzle Studio
 db-studio:
     doppler run -- pnpm run db:studio
+
+# Forward Stripe webhooks to local dev server
+stripe-listen:
+    stripe listen --forward-to localhost:3000/api/stripe/webhook

--- a/scripts/seed-classes.ts
+++ b/scripts/seed-classes.ts
@@ -13,28 +13,28 @@ async function seed() {
       title: "Prenatal Yoga",
       category: "class" as const,
       bookingType: "stripe" as const,
-      priceInPence: 1500,
+      priceInPence: 1250,
     },
     {
       slug: "postnatal",
       title: "Postnatal Yoga",
       category: "class" as const,
       bookingType: "stripe" as const,
-      priceInPence: 1500,
+      priceInPence: 1250,
     },
     {
       slug: "baby-yoga",
       title: "Baby Yoga & Massage",
       category: "class" as const,
       bookingType: "stripe" as const,
-      priceInPence: 1500,
+      priceInPence: 1250,
     },
     {
       slug: "vinyasa",
       title: "Vinyasa Yoga Seasonal Flow",
       category: "class" as const,
       bookingType: "stripe" as const,
-      priceInPence: 1500,
+      priceInPence: 1250,
     },
   ];
 

--- a/src/app/api/book/checkout/route.ts
+++ b/src/app/api/book/checkout/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { classes, schedules } from "@/lib/db/schema";
 import { getStripe } from "@/lib/stripe";
 
-const BUNDLE_PRICE_PENCE = 7500; // £75 for 6 classes — Gabrielle to confirm
+const BUNDLE_PRICE_PENCE = 6600;
 const BUNDLE_CREDITS = 6;
 
 export async function POST(request: Request) {

--- a/src/app/book/booking-client.tsx
+++ b/src/app/book/booking-client.tsx
@@ -350,7 +350,7 @@ export function BookingClient({ schedules }: { schedules: ScheduleRow[] }) {
           Save with a 6-Class Bundle
         </h2>
         <p className="text-deep-ocean mb-4">
-          6 classes for {formatPrice(7500)} &middot; Valid 90 days
+          6 classes for {formatPrice(6600)} &middot; Valid 90 days
         </p>
         <Link
           href="/book/bundle"

--- a/src/app/book/bundle/page.tsx
+++ b/src/app/book/bundle/page.tsx
@@ -53,7 +53,7 @@ export default function BookBundlePage() {
 
         <div className="bg-soft-moonstone/30 rounded-lg p-8 text-center mb-8">
           <p className="text-4xl font-heading text-deep-tide-blue mb-2">
-            &pound;75
+            &pound;66
           </p>
           <p className="text-deep-ocean">
             6 classes &middot; Valid for 90 days

--- a/tests/api/book-checkout.test.ts
+++ b/tests/api/book-checkout.test.ts
@@ -237,7 +237,7 @@ describe("POST /api/book/checkout", () => {
           expect.objectContaining({
             price_data: expect.objectContaining({
               currency: "gbp",
-              unit_amount: 7500,
+              unit_amount: 6600,
               product_data: expect.objectContaining({
                 name: "6-Class Bundle",
                 description: "6 classes, valid for 90 days from purchase",


### PR DESCRIPTION
## Summary
- Update bundle price to £66 (6600 pence) and class prices to £12.50 (1250 pence) per Gabrielle's confirmation
- Add `just stripe-listen` command for local Stripe webhook testing
- Update AGENTS.md pricing references

## Test plan
- [x] End-to-end Stripe Checkout tested locally with test card (4242...)
- [x] Webhook received and booking created in DB
- [x] All 38 unit tests passing
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)