### PR TITLE
fix: admin login hanging on sign-in

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -19,14 +19,18 @@ export default function AdminLoginPage() {
     setLoading(true);
     setError("");
 
-    const result = await authClient.signIn.email({ email, password });
-
-    if (result.error) {
-      setError("Invalid email or password");
-      setLoading(false);
-    } else {
-      router.push("/admin/schedule");
-    }
+    await authClient.signIn.email(
+      { email, password },
+      {
+        onSuccess: () => {
+          router.push("/admin/schedule");
+        },
+        onError: (ctx) => {
+          setError(ctx.error.message || "Invalid email or password");
+          setLoading(false);
+        },
+      },
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Login page was hanging after clicking Sign In — promise never resolved
- Switch from `const result = await signIn.email({...})` to callback pattern (`onSuccess`/`onError`) per Better Auth docs

## Test plan
- [ ] Login at /admin/login with valid credentials → redirects to /admin/schedule
- [ ] Login with wrong credentials → shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)