### PR TITLE
fix: admin auth broken in production (secure cookie prefix)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,9 @@ export function proxy(request: NextRequest) {
     request.nextUrl.pathname.startsWith("/admin") &&
     !request.nextUrl.pathname.startsWith("/admin/login")
   ) {
-    const token = request.cookies.get("better-auth.session_token");
+    const token =
+      request.cookies.get("better-auth.session_token") ||
+      request.cookies.get("__Secure-better-auth.session_token");
     if (!token) {
       return NextResponse.redirect(new URL("/admin/login", request.url));
     }


### PR DESCRIPTION
## Summary
The proxy protecting `/admin/*` routes checked for `better-auth.session_token` cookie, but Better Auth automatically prefixes cookies with `__Secure-` when running over HTTPS. So in production, the cookie was set as `__Secure-better-auth.session_token` but the proxy didn't recognise it — redirecting authenticated users back to login.

Now checks for both cookie names.

## Root cause
- Locally (HTTP): cookie is `better-auth.session_token` — proxy finds it
- Production (HTTPS): cookie is `__Secure-better-auth.session_token` — proxy missed it

## Test plan
- [ ] Login at /admin/login → redirects to /admin/schedule
- [ ] Refresh /admin/schedule → stays on page (not redirected to login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)