### PR TITLE
chore: auto-run migrations on Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "drizzle-kit migrate && next build",
     "start": "next start",
     "lint": "biome check --write .",
     "db:generate": "drizzle-kit generate",


### PR DESCRIPTION
## Summary
- Build command now runs `drizzle-kit migrate && next build`
- Prevents deploying code that references new schema columns before the migration exists
- Fixes the class of bug where webhook 500s because a column doesn't exist yet

## Test plan
- [x] Local build still works
- [ ] Vercel deployment applies pending migrations before building

🤖 Generated with [Claude Code](https://claude.com/claude-code)