### PR TITLE
fix: surface delete errors and add cancel-class action in admin

### DIFF
--- a/src/app/admin/schedule/page.tsx
+++ b/src/app/admin/schedule/page.tsx
@@ -77,7 +77,31 @@ export default function SchedulePage() {
     });
     if (res.ok) {
       await fetchSchedules();
+      return;
     }
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    window.alert(data.error || "Failed to delete schedule.");
+  }
+
+  async function handleCancelClass(id: number) {
+    if (
+      !window.confirm(
+        "Cancel this class? It will be hidden from the public calendar. Existing bookings remain — refund and notify customers separately.",
+      )
+    ) {
+      return;
+    }
+    const res = await fetch("/api/admin/schedules", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, status: "cancelled" }),
+    });
+    if (res.ok) {
+      await fetchSchedules();
+      return;
+    }
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    window.alert(data.error || "Failed to cancel class.");
   }
 
   function handleEdit(item: Schedule) {
@@ -386,6 +410,15 @@ export default function SchedulePage() {
                     >
                       Edit
                     </button>
+                    {item.schedules.status !== "cancelled" && (
+                      <button
+                        type="button"
+                        onClick={() => handleCancelClass(item.schedules.id)}
+                        className="text-bright-orange hover:text-deep-tide-blue text-sm mr-3"
+                      >
+                        Cancel
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={() => handleDelete(item.schedules.id)}

--- a/src/app/api/admin/schedules/route.ts
+++ b/src/app/api/admin/schedules/route.ts
@@ -1,7 +1,7 @@
 import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { classes, schedules } from "@/lib/db/schema";
+import { bookings, classes, schedules } from "@/lib/db/schema";
 
 export async function GET() {
   const result = await db
@@ -164,6 +164,23 @@ export async function DELETE(request: Request) {
   if (!id) {
     return NextResponse.json({ error: "Missing schedule ID" }, { status: 400 });
   }
+
+  const existingBookings = await db
+    .select({ id: bookings.id })
+    .from(bookings)
+    .where(eq(bookings.scheduleId, id))
+    .limit(1);
+
+  if (existingBookings.length > 0) {
+    return NextResponse.json(
+      {
+        error:
+          "Cannot delete a schedule that has bookings. Cancel the class instead.",
+      },
+      { status: 409 },
+    );
+  }
+
   await db.delete(schedules).where(eq(schedules.id, id));
   return NextResponse.json({ deleted: true });
 }

--- a/tests/admin/schedules.test.ts
+++ b/tests/admin/schedules.test.ts
@@ -5,15 +5,24 @@ const {
   mockSelectFrom,
   mockInnerJoin,
   mockOrderBy,
+  mockSelectWhere,
+  mockSelectLimit,
   mockInsertValues,
   mockReturning,
   mockUpdateSet,
   mockUpdateWhere,
   mockUpdateReturning,
+  mockDeleteFrom,
+  mockDeleteWhere,
 } = vi.hoisted(() => {
   const mockOrderBy = vi.fn().mockResolvedValue([]);
   const mockInnerJoin = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-  const mockSelectFrom = vi.fn().mockReturnValue({ innerJoin: mockInnerJoin });
+  const mockSelectLimit = vi.fn().mockResolvedValue([]);
+  const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit });
+  const mockSelectFrom = vi.fn().mockReturnValue({
+    innerJoin: mockInnerJoin,
+    where: mockSelectWhere,
+  });
   const mockReturning = vi.fn().mockResolvedValue([
     {
       id: 1,
@@ -32,15 +41,21 @@ const {
     .fn()
     .mockReturnValue({ returning: mockUpdateReturning });
   const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+  const mockDeleteFrom = vi.fn().mockReturnValue({ where: mockDeleteWhere });
   return {
     mockSelectFrom,
     mockInnerJoin,
     mockOrderBy,
+    mockSelectWhere,
+    mockSelectLimit,
     mockInsertValues,
     mockReturning,
     mockUpdateSet,
     mockUpdateWhere,
     mockUpdateReturning,
+    mockDeleteFrom,
+    mockDeleteWhere,
   };
 });
 
@@ -55,12 +70,14 @@ vi.mock("@/lib/db", () => ({
     update: vi.fn().mockReturnValue({
       set: mockUpdateSet,
     }),
+    delete: mockDeleteFrom,
   },
 }));
 
 vi.mock("@/lib/db/schema", () => ({
   classes: { id: "id", active: "active" },
   schedules: { id: "id", classId: "class_id" },
+  bookings: { id: "id", scheduleId: "schedule_id" },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -68,12 +85,15 @@ vi.mock("drizzle-orm", () => ({
   desc: vi.fn((col: unknown) => col),
 }));
 
-import { GET, POST, PUT } from "@/app/api/admin/schedules/route";
+import { DELETE, GET, POST, PUT } from "@/app/api/admin/schedules/route";
 
 describe("GET /api/admin/schedules", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSelectFrom.mockReturnValue({ innerJoin: mockInnerJoin });
+    mockSelectFrom.mockReturnValue({
+      innerJoin: mockInnerJoin,
+      where: mockSelectWhere,
+    });
     mockInnerJoin.mockReturnValue({ orderBy: mockOrderBy });
     mockOrderBy.mockResolvedValue([]);
   });
@@ -411,5 +431,64 @@ describe("PUT /api/admin/schedules", () => {
     expect(response.status).toBe(404);
     const body = await response.json();
     expect(body.error).toBe("Schedule not found");
+  });
+});
+
+describe("DELETE /api/admin/schedules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectFrom.mockReturnValue({
+      innerJoin: mockInnerJoin,
+      where: mockSelectWhere,
+    });
+    mockSelectWhere.mockReturnValue({ limit: mockSelectLimit });
+    mockSelectLimit.mockResolvedValue([]);
+    mockDeleteFrom.mockReturnValue({ where: mockDeleteWhere });
+    mockDeleteWhere.mockResolvedValue(undefined);
+  });
+
+  it("returns 200 and deletes the schedule when no bookings exist", async () => {
+    mockSelectLimit.mockResolvedValue([]);
+
+    const request = new Request("http://localhost:3000/api/admin/schedules", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: 1 }),
+    });
+
+    const response = await DELETE(request);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.deleted).toBe(true);
+    expect(mockDeleteFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 and does not delete when any booking exists", async () => {
+    mockSelectLimit.mockResolvedValue([{ id: 42 }]);
+
+    const request = new Request("http://localhost:3000/api/admin/schedules", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: 1 }),
+    });
+
+    const response = await DELETE(request);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toMatch(/cancel the class instead/i);
+    expect(mockDeleteFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const request = new Request("http://localhost:3000/api/admin/schedules", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await DELETE(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Missing schedule ID");
   });
 });


### PR DESCRIPTION
## Summary
- Production bug: clicking Delete on a class in `/admin/schedule` did nothing — confirm dialog appeared, but the row never disappeared. Vercel logs showed a 500 from `bookings_schedule_id_schedules_id_fk` (FK violation), and the client silently ignored the non-OK response.
- API now pre-checks for bookings and returns 409 with `"Cannot delete a schedule that has bookings. Cancel the class instead."` rather than letting Postgres throw a 500. The client surfaces the message via `window.alert`.
- Adds a **Cancel** button on each schedule row that PUTs `status='cancelled'`, hiding the class from the public calendar (already filtered by `status='open'` in `src/app/book/page.tsx`) while preserving booking history.

## Test plan
- [x] Vitest: 59 passed (3 new DELETE cases — success, 409 when bookings exist, 400 on missing id).
- [x] `pnpm exec biome check` clean.
- [x] `pnpm exec tsc --noEmit` clean.
- [ ] Manual: in admin, delete a schedule with no bookings → row disappears.
- [ ] Manual: delete a schedule with at least one booking → alert shows the API error message; row stays.
- [ ] Manual: click Cancel on a schedule with bookings → status flips to `cancelled` and the class drops off the public `/book` calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)