### PR TITLE
fix(admin-login): full reload on sign-in to avoid cookie race

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,25 +11,31 @@ export default function AdminLoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
     setError("");
 
-    await authClient.signIn.email(
-      { email, password },
-      {
-        onSuccess: () => {
-          router.push("/admin/schedule");
+    try {
+      await authClient.signIn.email(
+        { email, password },
+        {
+          onSuccess: () => {
+            // Full reload so the just-set session cookie is in the jar for
+            // the next request, bypassing RSC prefetch/router cache.
+            window.location.assign("/admin/schedule");
+          },
+          onError: (ctx) => {
+            setError(ctx.error.message || "Invalid email or password");
+            setLoading(false);
+          },
         },
-        onError: (ctx) => {
-          setError(ctx.error.message || "Invalid email or password");
-          setLoading(false);
-        },
-      },
-    );
+      );
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setLoading(false);
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary

- `router.push` after a successful `signIn.email` raced the just-set `__Secure-better-auth.session_token` cookie against the RSC fetch for `/admin/schedule`, so the proxy could redirect users back to `/admin/login` — silently on Chrome/Android (refresh recovers), persistently on iOS Safari.
- Switched the post-login redirect to `window.location.assign("/admin/schedule")` so it's a top-level navigation that always carries the cookie and bypasses any RSC prefetch / router cache.
- Wrapped the `await` in `try/catch` so a thrown error can't strand the button in the disabled state (mirrors the failure mode that `05a2570 "signIn.email was hanging"` previously addressed).

## Test plan

- [ ] Desktop Chrome: load `/admin/login` cold, sign in on first attempt — should land on `/admin/schedule` without needing to refresh.
- [ ] Android Chrome: same as above.
- [ ] **iPhone Safari: sign in on first attempt — should now work where it previously never did.**
- [ ] Bad credentials: error message renders and button re-enables.
- [ ] Already-authenticated users still reach admin pages (proxy unaffected).

## Notes

`src/app/admin/layout.tsx` still wraps the login page, so the admin nav with prefetching `<Link>`s renders above the sign-in form. With the full-reload fix that no longer causes a functional bug, but it's odd UX — happy to move login under a route group (`admin/(public)/login/...`) in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)