### PR TITLE
fix(book): order upcoming schedules so calendar opens on earliest month

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -13,7 +13,8 @@ export default async function BookPage() {
     .select()
     .from(schedules)
     .innerJoin(classes, eq(schedules.classId, classes.id))
-    .where(and(gte(schedules.date, today), eq(schedules.status, "open")));
+    .where(and(gte(schedules.date, today), eq(schedules.status, "open")))
+    .orderBy(schedules.date, schedules.startTime);
 
   const activeBundles = await db
     .select()


### PR DESCRIPTION
## Summary

- The booking calendar's initial month was derived from `schedules[0]`, but the upcoming-schedules query had no `ORDER BY`. Postgres could return a later month's row first, so the calendar would open on (e.g.) June even when May still had upcoming classes.
- Added `.orderBy(schedules.date, schedules.startTime)` so `schedules[0]` is always the earliest upcoming class.
- Side benefit: the class list under a selected day now displays in time order.

## Test plan

- [ ] Visit `/book` while there are upcoming classes in the current month — calendar opens on the current month.
- [ ] Visit `/book` when the current month has no upcoming classes — calendar opens on the next month that does.
- [ ] Pick a day with multiple classes — classes appear earliest-time first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)