### PR TITLE
fix(proxy): protect /api/admin/* routes with auth check

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,21 +2,28 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export function proxy(request: NextRequest) {
-  if (
-    request.nextUrl.pathname.startsWith("/admin") &&
-    !request.nextUrl.pathname.startsWith("/admin/login")
-  ) {
-    const token =
-      request.cookies.get("better-auth.session_token") ||
-      request.cookies.get("__Secure-better-auth.session_token");
-    if (!token) {
-      return NextResponse.redirect(new URL("/admin/login", request.url));
-    }
+  const { pathname } = request.nextUrl;
+  const isAdminPage =
+    pathname.startsWith("/admin") && !pathname.startsWith("/admin/login");
+  const isAdminApi = pathname.startsWith("/api/admin");
+
+  if (!isAdminPage && !isAdminApi) {
+    return NextResponse.next();
   }
 
-  return NextResponse.next();
+  const token =
+    request.cookies.get("better-auth.session_token") ||
+    request.cookies.get("__Secure-better-auth.session_token");
+  if (token) {
+    return NextResponse.next();
+  }
+
+  if (isAdminApi) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return NextResponse.redirect(new URL("/admin/login", request.url));
 }
 
 export const config = {
-  matcher: ["/admin/:path*"],
+  matcher: ["/admin/:path*", "/api/admin/:path*"],
 };

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { proxy } from "@/proxy";
+
+type CookieEntry = { name: string; value: string };
+
+function makeRequest(pathname: string, cookies: CookieEntry[] = []) {
+  const url = `http://localhost:3000${pathname}`;
+  const cookieMap = new Map(cookies.map((c) => [c.name, c]));
+  return {
+    nextUrl: new URL(url),
+    url,
+    cookies: {
+      get(name: string) {
+        return cookieMap.get(name);
+      },
+    },
+  } as unknown as Parameters<typeof proxy>[0];
+}
+
+describe("proxy", () => {
+  it("passes through non-admin paths without checking auth", () => {
+    const res = proxy(makeRequest("/"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("passes through /admin/login without checking auth", () => {
+    const res = proxy(makeRequest("/admin/login"));
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("redirects unauthenticated /admin/* page requests to /admin/login", () => {
+    const res = proxy(makeRequest("/admin/schedule"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/admin/login",
+    );
+  });
+
+  it("returns 401 JSON for unauthenticated /api/admin/* requests", async () => {
+    const res = proxy(makeRequest("/api/admin/waitlist?scheduleId=1"));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("allows /admin/* page requests when session cookie is present", () => {
+    const res = proxy(
+      makeRequest("/admin/schedule", [
+        { name: "better-auth.session_token", value: "abc" },
+      ]),
+    );
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("allows /api/admin/* requests when session cookie is present", () => {
+    const res = proxy(
+      makeRequest("/api/admin/waitlist", [
+        { name: "better-auth.session_token", value: "abc" },
+      ]),
+    );
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("accepts the __Secure- prefixed cookie", () => {
+    const res = proxy(
+      makeRequest("/api/admin/waitlist", [
+        { name: "__Secure-better-auth.session_token", value: "abc" },
+      ]),
+    );
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary
The proxy matcher only caught `/admin/:path*` page routes, leaving every `/api/admin/*` endpoint publicly callable. Anyone could read customer names, emails, bookings, contact submissions, and now waitlist entries by hitting the JSON endpoints directly.

This was pre-existing — every admin API on the codebase had the gap — but the class waiting list feature added new PII flow through `/api/admin/waitlist`, so it's worth closing now.

## Changes
- `src/proxy.ts`: extend matcher to `["/admin/:path*", "/api/admin/:path*"]`.
- Differentiate the unauthenticated response: API paths return `401 { error: "Unauthorized" }`, page paths still redirect to `/admin/login` (returning a redirect from an API call would be misleading).
- New `tests/proxy.test.ts` with 7 cases covering both legacy and new behaviour.

## Posture note
The proxy still only checks for cookie *presence*, not session validity — same as before. Tightening to full session validation (e.g. via Better Auth's `getSession`) is a separate hardening pass.

## Test plan
- [ ] `curl -i http://localhost:3000/api/admin/waitlist?scheduleId=1` returns `401 {"error":"Unauthorized"}` without a session cookie
- [ ] Same request with a valid admin session cookie returns the entry list as before
- [ ] `/admin/schedule` still redirects to `/admin/login` when not signed in
- [ ] `/admin/login` itself still loads without redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)