### PR TITLE
fix(bookings): prevent duplicate bookings + restore bundle credit on cancel

### DIFF
--- a/src/app/api/admin/bookings/route.ts
+++ b/src/app/api/admin/bookings/route.ts
@@ -1,7 +1,7 @@
 import { desc, eq, sql } from "drizzle-orm";
 import { after, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { bookings, classes, schedules } from "@/lib/db/schema";
+import { bookings, bundles, classes, schedules } from "@/lib/db/schema";
 import { sendRescheduleNotification } from "@/lib/email";
 
 export async function GET() {
@@ -56,6 +56,18 @@ export async function PUT(request: Request) {
         .update(schedules)
         .set({ bookedCount: sql`GREATEST(${schedules.bookedCount} - 1, 0)` })
         .where(eq(schedules.id, existing[0].scheduleId));
+
+      // If the booking was paid for with a bundle credit, give the credit back
+      // (capped at the bundle total) and re-activate an exhausted bundle.
+      if (existing[0].bundleId) {
+        await tx
+          .update(bundles)
+          .set({
+            creditsRemaining: sql`LEAST(${bundles.creditsRemaining} + 1, ${bundles.creditsTotal})`,
+            status: sql`CASE WHEN ${bundles.status} = 'exhausted' THEN 'active'::bundle_status ELSE ${bundles.status} END`,
+          })
+          .where(eq(bundles.id, existing[0].bundleId));
+      }
     });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/book/checkout/route.ts
+++ b/src/app/api/book/checkout/route.ts
@@ -1,7 +1,7 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { bundleConfig, classes, schedules } from "@/lib/db/schema";
+import { bookings, bundleConfig, classes, schedules } from "@/lib/db/schema";
 import { getStripe } from "@/lib/stripe";
 
 export async function POST(request: Request) {
@@ -89,6 +89,25 @@ export async function POST(request: Request) {
 
   if (schedule.bookedCount >= schedule.capacity) {
     return NextResponse.json({ error: "Class is full" }, { status: 400 });
+  }
+
+  // Prevent paying to book a class the customer is already booked onto.
+  const existingBooking = await db
+    .select()
+    .from(bookings)
+    .where(
+      and(
+        eq(bookings.scheduleId, scheduleId),
+        eq(bookings.customerEmail, customerEmail),
+        ne(bookings.status, "cancelled"),
+      ),
+    );
+
+  if (existingBooking.length > 0) {
+    return NextResponse.json(
+      { error: "You already have a booking for this class" },
+      { status: 409 },
+    );
   }
 
   const session = await stripe.checkout.sessions.create({

--- a/src/app/api/book/redeem/route.ts
+++ b/src/app/api/book/redeem/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, eq, gt, ne, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { bookings, bundles, schedules } from "@/lib/db/schema";
@@ -33,6 +33,26 @@ export async function POST(request: Request) {
   }
 
   const bundle = activeBundles[0];
+
+  // Prevent double-booking the same class with bundle credits.
+  const existingBooking = await db
+    .select()
+    .from(bookings)
+    .where(
+      and(
+        eq(bookings.scheduleId, scheduleId),
+        eq(bookings.customerEmail, customerEmail),
+        ne(bookings.status, "cancelled"),
+      ),
+    );
+
+  if (existingBooking.length > 0) {
+    return NextResponse.json(
+      { error: "You already have a booking for this class" },
+      { status: 409 },
+    );
+  }
+
   const newCredits = bundle.creditsRemaining - 1;
 
   await db.transaction(async (tx) => {

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { after, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import {
@@ -40,6 +40,25 @@ export async function POST(request: Request) {
 
     if (metadata?.type === "individual") {
       const scheduleId = Number.parseInt(metadata.scheduleId, 10);
+
+      // Idempotency guard: Stripe may deliver an event more than once, and a
+      // customer may have an existing booking for this class. Don't create a
+      // duplicate or double-count the seat.
+      const existingBooking = await db
+        .select()
+        .from(bookings)
+        .where(
+          and(
+            eq(bookings.scheduleId, scheduleId),
+            eq(bookings.customerEmail, metadata.customerEmail),
+            ne(bookings.status, "cancelled"),
+          ),
+        );
+
+      if (existingBooking.length > 0) {
+        return NextResponse.json({ received: true });
+      }
+
       await db.transaction(async (tx) => {
         await tx.insert(bookings).values({
           scheduleId,

--- a/tests/admin/bookings.test.ts
+++ b/tests/admin/bookings.test.ts
@@ -40,9 +40,20 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/db/schema", () => ({
-  bookings: { id: "id", scheduleId: "schedule_id", status: "status" },
+  bookings: {
+    id: "id",
+    scheduleId: "schedule_id",
+    status: "status",
+    bundleId: "bundle_id",
+  },
   schedules: { id: "id", classId: "class_id", bookedCount: "booked_count" },
   classes: { id: "id" },
+  bundles: {
+    id: "id",
+    creditsRemaining: "credits_remaining",
+    creditsTotal: "credits_total",
+    status: "status",
+  },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -156,6 +167,31 @@ describe("PUT /api/admin/bookings — cancel branch (regression)", () => {
     expect(mockTransaction).toHaveBeenCalled();
     expect(mockTxUpdateSet).toHaveBeenCalledWith({ status: "cancelled" });
     expect(mockTxUpdateSet).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not touch any bundle when cancelling a non-bundle booking", async () => {
+    mockSelectWhere.mockResolvedValueOnce([SAMPLE_BOOKING]);
+    await PUT(makeRequest({ id: 1, status: "cancelled" }));
+    const bundleUpdateCall = mockTxUpdateSet.mock.calls.find(
+      (c) => c[0] && typeof c[0] === "object" && "creditsRemaining" in c[0],
+    );
+    expect(bundleUpdateCall).toBeUndefined();
+  });
+
+  it("restores a bundle credit when cancelling a bundle-funded booking", async () => {
+    mockSelectWhere.mockResolvedValueOnce([{ ...SAMPLE_BOOKING, bundleId: 7 }]);
+    const response = await PUT(makeRequest({ id: 1, status: "cancelled" }));
+    expect(response.status).toBe(200);
+
+    // booking + schedule + bundle updates
+    expect(mockTxUpdateSet).toHaveBeenCalledTimes(3);
+
+    // The bundle update restores credits and re-activates the bundle
+    const bundleUpdateCall = mockTxUpdateSet.mock.calls.find(
+      (c) => c[0] && typeof c[0] === "object" && "creditsRemaining" in c[0],
+    );
+    expect(bundleUpdateCall).toBeDefined();
+    expect(bundleUpdateCall?.[0]).toHaveProperty("status");
   });
 });
 

--- a/tests/api/book-checkout.test.ts
+++ b/tests/api/book-checkout.test.ts
@@ -39,11 +39,18 @@ vi.mock("@/lib/db/schema", () => ({
   classes: { id: "id" },
   schedules: { id: "id", classId: "class_id" },
   bundleConfig: { id: "id", active: "active" },
+  bookings: {
+    id: "id",
+    scheduleId: "schedule_id",
+    customerEmail: "customer_email",
+    status: "status",
+  },
 }));
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((...args: unknown[]) => args),
   and: vi.fn((...args: unknown[]) => args),
+  ne: vi.fn((...args: unknown[]) => args),
 }));
 
 import { POST } from "@/app/api/book/checkout/route";
@@ -51,7 +58,10 @@ import { POST } from "@/app/api/book/checkout/route";
 describe("POST /api/book/checkout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSelectFrom.mockReturnValue({ innerJoin: mockInnerJoin });
+    mockSelectFrom.mockReturnValue({
+      innerJoin: mockInnerJoin,
+      where: mockWhere,
+    });
     mockInnerJoin.mockReturnValue({ where: mockWhere });
     mockWhere.mockResolvedValue([]);
     mockCheckoutSessionsCreate.mockResolvedValue({
@@ -158,20 +168,22 @@ describe("POST /api/book/checkout", () => {
   });
 
   it("returns checkout URL for valid booking", async () => {
-    mockWhere.mockResolvedValue([
-      {
-        schedules: {
-          id: 1,
-          status: "open",
-          bookedCount: 2,
-          capacity: 8,
-          date: "2026-05-01",
-          startTime: "09:00",
-          endTime: "10:00",
+    mockWhere
+      .mockResolvedValueOnce([
+        {
+          schedules: {
+            id: 1,
+            status: "open",
+            bookedCount: 2,
+            capacity: 8,
+            date: "2026-05-01",
+            startTime: "09:00",
+            endTime: "10:00",
+          },
+          classes: { id: 1, title: "Morning Yoga", priceInPence: 1200 },
         },
-        classes: { id: 1, title: "Morning Yoga", priceInPence: 1200 },
-      },
-    ]);
+      ])
+      .mockResolvedValueOnce([]);
 
     const request = new Request("http://localhost:3000/api/book/checkout", {
       method: "POST",
@@ -213,6 +225,41 @@ describe("POST /api/book/checkout", () => {
         }),
       }),
     );
+  });
+
+  it("returns 409 when customer already has a booking for this schedule", async () => {
+    mockWhere
+      .mockResolvedValueOnce([
+        {
+          schedules: {
+            id: 1,
+            status: "open",
+            bookedCount: 2,
+            capacity: 8,
+            date: "2026-05-01",
+            startTime: "09:00",
+            endTime: "10:00",
+          },
+          classes: { id: 1, title: "Morning Yoga", priceInPence: 1200 },
+        },
+      ])
+      .mockResolvedValueOnce([{ id: 99, status: "confirmed" }]);
+
+    const request = new Request("http://localhost:3000/api/book/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scheduleId: 1,
+        customerName: "Jane Doe",
+        customerEmail: "jane@example.com",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("You already have a booking for this class");
+    expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled();
   });
 
   it("returns checkout URL for bundle purchase", async () => {

--- a/tests/api/book-redeem.test.ts
+++ b/tests/api/book-redeem.test.ts
@@ -55,7 +55,12 @@ vi.mock("@/lib/db/schema", () => ({
     creditsRemaining: "credits_remaining",
     expiresAt: "expires_at",
   },
-  bookings: { id: "id", scheduleId: "schedule_id" },
+  bookings: {
+    id: "id",
+    scheduleId: "schedule_id",
+    customerEmail: "customer_email",
+    status: "status",
+  },
   schedules: { id: "id", bookedCount: "booked_count" },
 }));
 
@@ -63,6 +68,7 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn((...args: unknown[]) => args),
   and: vi.fn((...args: unknown[]) => args),
   gt: vi.fn((...args: unknown[]) => args),
+  ne: vi.fn((...args: unknown[]) => args),
   sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
     strings,
     values,
@@ -126,16 +132,18 @@ describe("POST /api/book/redeem", () => {
   });
 
   it("returns 200 for valid bundle redemption", async () => {
-    mockSelectWhere.mockResolvedValue([
-      {
-        id: 10,
-        customerEmail: "jane@example.com",
-        creditsTotal: 6,
-        creditsRemaining: 4,
-        status: "active",
-        expiresAt: new Date("2026-12-31"),
-      },
-    ]);
+    mockSelectWhere
+      .mockResolvedValueOnce([
+        {
+          id: 10,
+          customerEmail: "jane@example.com",
+          creditsTotal: 6,
+          creditsRemaining: 4,
+          status: "active",
+          expiresAt: new Date("2026-12-31"),
+        },
+      ])
+      .mockResolvedValueOnce([]);
 
     const request = new Request("http://localhost:3000/api/book/redeem", {
       method: "POST",
@@ -177,17 +185,53 @@ describe("POST /api/book/redeem", () => {
     );
   });
 
-  it("sets bundle status to exhausted when credits reach 0", async () => {
-    mockSelectWhere.mockResolvedValue([
-      {
-        id: 10,
+  it("returns 409 when customer already has a booking for this schedule", async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([
+        {
+          id: 10,
+          customerEmail: "jane@example.com",
+          creditsTotal: 6,
+          creditsRemaining: 4,
+          status: "active",
+          expiresAt: new Date("2026-12-31"),
+        },
+      ])
+      .mockResolvedValueOnce([{ id: 99, status: "confirmed" }]);
+
+    const request = new Request("http://localhost:3000/api/book/redeem", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scheduleId: 1,
+        customerName: "Jane Doe",
         customerEmail: "jane@example.com",
-        creditsTotal: 6,
-        creditsRemaining: 1,
-        status: "active",
-        expiresAt: new Date("2026-12-31"),
-      },
-    ]);
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("You already have a booking for this class");
+
+    // No booking should be created and no credit spent
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("sets bundle status to exhausted when credits reach 0", async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([
+        {
+          id: 10,
+          customerEmail: "jane@example.com",
+          creditsTotal: 6,
+          creditsRemaining: 1,
+          status: "active",
+          expiresAt: new Date("2026-12-31"),
+        },
+      ])
+      .mockResolvedValueOnce([]);
 
     const request = new Request("http://localhost:3000/api/book/redeem", {
       method: "POST",

--- a/tests/api/stripe-webhook.test.ts
+++ b/tests/api/stripe-webhook.test.ts
@@ -92,7 +92,12 @@ vi.mock("@/lib/db", () => ({
 }));
 
 vi.mock("@/lib/db/schema", () => ({
-  bookings: { id: "id", scheduleId: "schedule_id" },
+  bookings: {
+    id: "id",
+    scheduleId: "schedule_id",
+    customerEmail: "customer_email",
+    status: "status",
+  },
   bundles: { id: "id" },
   bundleConfig: { id: "id" },
   schedules: { id: "id", bookedCount: "booked_count" },
@@ -154,7 +159,13 @@ describe("POST /api/stripe/webhook", () => {
   });
 
   it("creates booking inside a transaction for individual purchase", async () => {
-    // Mock schedule+class query for email sending in after()
+    // 1st select() → existence check finds no current booking
+    mockBundleConfigSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+    // 2nd select() → schedule+class query for email sending in after()
     mockBundleConfigSelect.mockReturnValueOnce({
       from: vi.fn().mockReturnValue({
         innerJoin: vi.fn().mockReturnValue({
@@ -230,6 +241,45 @@ describe("POST /api/stripe/webhook", () => {
         customerName: "Jane Doe",
       }),
     );
+  });
+
+  it("skips creating a duplicate individual booking when one already exists", async () => {
+    // 1st select() → existence check finds an active booking
+    mockBundleConfigSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: 99, status: "confirmed" }]),
+      }),
+    });
+
+    mockConstructEvent.mockReturnValue({
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test_dupe",
+          metadata: {
+            type: "individual",
+            scheduleId: "1",
+            customerName: "Jane Doe",
+            customerEmail: "jane@example.com",
+          },
+        },
+      },
+    } as unknown as Stripe.Event);
+
+    const request = new Request("http://localhost:3000/api/stripe/webhook", {
+      method: "POST",
+      headers: { "stripe-signature": "valid" },
+      body: "{}",
+    });
+
+    const response = await POST(request);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(response.status).toBe(200);
+
+    // No second booking created, no seat counted, no email fired
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockSendBookingConfirmation).not.toHaveBeenCalled();
   });
 
   it("creates bundle record for bundle purchase", async () => {


### PR DESCRIPTION
## Problem

A bundle customer (production: Kirby Friend) was able to book onto the **same class twice**, consuming two credits. Investigation found two defects:

1. **No duplicate guard** on any booking-creation path — `redeem`, `checkout`, or the Stripe `webhook`.
2. **Cancel silently burned the credit** — the admin cancel branch only flipped booking status and freed the seat; it never restored `creditsRemaining`. So cancelling the duplicate would *not* have given her the credit back.

## Changes (Phase 1 — application-level, no migration)

| Path | Behaviour |
|---|---|
| `POST /api/book/redeem` | 409 if a non-cancelled booking already exists for that schedule/email |
| `POST /api/book/checkout` (individual) | 409 before creating a Stripe session — stops paying twice |
| `POST /api/stripe/webhook` (individual) | Skips insert + seat increment when a booking already exists; also makes the handler idempotent against Stripe's at-least-once event delivery |
| `PUT /api/admin/bookings` (cancel) | Restores the bundle credit (`+1`, capped at `creditsTotal`) and flips `exhausted → active` when the cancelled booking was bundle-funded |

Reschedule intentionally keeps the credit spent (the customer still attends a class); an expired bundle gets its count back but stays expired (only `exhausted` re-activates).

## Remediating Kirby

Once this is live, Gabrielle cancels the duplicate in the admin UI and the credit is restored automatically — no manual SQL needed. A read-only reconciliation query (credits spent vs. active bundle bookings) is available to confirm.

## Follow-up: Phase 2 (separate PR)

A **partial unique index** `bookings (schedule_id, customer_email) WHERE status <> 'cancelled'` adds DB-level defense in depth. It ships separately because `build` auto-runs `drizzle-kit migrate`, and the index cannot be created while a duplicate row still exists in production — so prod duplicates must be cleared first.

## Testing

TDD throughout (failing test → implement → pass). Full suite **116/116 pass**, `tsc --noEmit` clean, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)