### PR TITLE
chore(agents): gate notification and deploy-config paths for human sign-off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,4 +169,4 @@ Single-context: one `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/age
 
 ### Review gates
 
-Estate defaults plus a `payments` gate (Stripe, booking, pricing paths) — matching PRs get `human-signoff` and wait for a human merge. See `docs/agents/review-gates.yaml`.
+Estate defaults plus three repo gates — `payments` (Stripe, booking, pricing paths), `notifications` (cron routes and the email helper) and `deploy-config` (`vercel.json`/`vercel.ts`, where cron schedules live). Matching PRs get `human-signoff` and wait for a human merge. See `docs/agents/review-gates.yaml`.

--- a/docs/agents/review-gates.yaml
+++ b/docs/agents/review-gates.yaml
@@ -14,3 +14,14 @@ human_signoff:
     - "**/api/stripe/**"
     - "**/api/book/**"
     - "**/admin/pricing/**"
+  # Anything that emails a customer, or the scheduled jobs that trigger it.
+  # A bad send goes out once and cannot be recalled, so these never auto-land.
+  notifications:
+    - "**/api/cron/**"
+    - "**/email.ts"
+    - "**/email/**"
+  # Cron schedules live in the deployment config, and this plan permits only
+  # daily schedules — a sub-daily entry fails the deploy rather than a check.
+  deploy-config:
+    - "**/vercel.json"
+    - "**/vercel.ts"


### PR DESCRIPTION
## Why

Customer-facing email cannot be recalled once it has gone out, and cron schedules live in the deployment config where this plan permits **daily schedules only** — a sub-daily entry fails the deploy rather than a check. Neither was gated.

Surfaced while breaking down the [Waiting-list seat offers](https://github.com/lennons301/moontide/milestone/1) milestone (#44). Six of its seven slices already matched a gate, but #51 — which settles expired offers and emails customers — touched only a cron route, the email helper and the scheduling config, so it would have auto-landed.

## What changed

Two additive repo gates. Estate defaults are untouched, and the existing `payments` gate is unchanged.

| Category | Globs |
|---|---|
| `notifications` | `**/api/cron/**`, `**/email.ts`, `**/email/**` |
| `deploy-config` | `**/vercel.json`, `**/vercel.ts` |

`AGENTS.md` updated to describe all three repo gates rather than just `payments`.

## Verification

Run against the estate evaluator (`scripts/review-gates-lib.sh`) with the real config pair, not by inspection:

```
GATED    src/app/api/cron/waitlist-sweep/route.ts   <- notifications(**/api/cron/**)
GATED    src/lib/email.ts                           <- notifications(**/email.ts)
GATED    vercel.json                                <- deploy-config(**/vercel.json)
GATED    src/app/api/book/redeem/route.ts           <- payments(**/api/book/**)
GATED    src/app/api/stripe/webhook/route.ts        <- payments(**/api/stripe/**)
GATED    drizzle/migrations/0012_offer_fields.sql   <- data-migrations
GATED    src/app/admin/bookings/page.tsx            <- visual-ui(**/app/**/page.*)
ungated  src/lib/db/schema.ts
ungated  src/lib/waitlist/offers.ts
```

`vercel.json` matches via the evaluator's leading-`**/` root fallback. `just lint` clean.

Note `src/lib/db/schema.ts` is ungated on its own — in practice a schema change always ships with a migration, which is gated by the estate `data-migrations` category.

## Notes

- This PR gates itself: the estate `ci-secrets` category includes `**/review-gates.yaml` specifically so a PR cannot un-gate itself. Expect `human-signoff` and a manual merge.
- Strictness is deliberately a first cut and can be relaxed later — `**/email.ts` will fire on any change to the email helper, including copy tweaks.
- **Unrelated issue found:** `.husky/pre-commit` is not executable (`-rw-r--r--`), so git skips it. Pre-commit lint has not been running for anyone. Not fixed here to keep this PR single-purpose — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)